### PR TITLE
Change @stderr.lines to @stderr.each in spec_state.rb

### DIFF
--- a/lib/guard/mocha_node/spec_state.rb
+++ b/lib/guard/mocha_node/spec_state.rb
@@ -25,7 +25,7 @@ module Guard
           line = @stdout.gets
           print line if !line.strip.empty?
         end
-        @stderr.lines { |line| print line }
+        @stderr.each { |line| print line }
         @exitstatus = @io[THREAD].value rescue ERROR_CODE
         close_io
         update_passed_and_fixed

--- a/spec/lib/spec_state_spec.rb
+++ b/spec/lib/spec_state_spec.rb
@@ -22,7 +22,7 @@ describe Guard::MochaNode::SpecState do
     let(:io) { [
                 double("stdin",  :close => true),
                 double("stdout", :close => true, :lines => [], :eof? => true),
-                double("stderr", :close => true, :lines => []),
+                double("stderr", :close => true, :each => []),
                 double("thread", :value => 0)
                ] }
     let(:some_paths)   { %w(some paths) }


### PR DESCRIPTION
IO#lines has been deprecated in Ruby 2.0.  Changing lines to each fixes the issue and is backwards compatible with Rubies 1.8.7 and 1.9.3.
